### PR TITLE
fix(xtuner): SQL syntax error

### DIFF
--- a/src/gausskernel/dbmind/tools/xtuner/tuner/character.py
+++ b/src/gausskernel/dbmind/tools/xtuner/tuner/character.py
@@ -114,7 +114,7 @@ class OpenGaussMetric:
     @property
     def current_locks_count(self):
         return self._get_numeric_metric(
-            "select count(1) from pg_locks where transactionid in (select transaction from pg_prepared_xacts)")
+            "select count(1) from pg_locks where transactionid in (select transaction from pg_prepared_xacts);")
 
     @property
     def checkpoint_dirty_writing_time_window(self):


### PR DESCRIPTION
Semicolon at the end of the SQL line in func ”current_locks_count“